### PR TITLE
Chaning counter names and providing autorefnames for hyperref

### DIFF
--- a/coqtheorem.sty
+++ b/coqtheorem.sty
@@ -19,6 +19,14 @@
   \newcommand{\coqitem}[1][]{\stepcounter{enumi}\item[{\coqlink[#1]{\theenumi.}}]}
 }%
 
+\newcommand*\ifcounter[1]{%
+  \ifcsname c@#1\endcsname
+    \expandafter\@firstoftwo
+  \else
+    \expandafter\@secondoftwo
+  \fi
+}
+
 \@ifclassloaded{llncs}{
   % If the class is LLNCS:
   \let\theorem\relax
@@ -29,7 +37,8 @@
 
   \newcommand{\genFancyTheoremEnvironment}[1]{%
     \expandafter\newcommand\csname #1AuxCoqautorefname\endcsname{\csname #1autorefname\endcsname}
-    \spnewtheorem{#1Aux}{}{\bfseries\theoremtype}{\itshape}
+    \ifcounter{#1}{}{\newcounter{#1}}
+    \spnewtheorem{#1Aux}{#1}{\bfseries\theoremtype}{\itshape}
     \spnewtheorem{#1AuxCoq}[#1Aux]{}{\bfseries \coqlink[\theoremname]{\theoremtype}}{{\bfseries\showname}\itshape\label{coq:\theoremname}}
     \NewDocumentEnvironment{#1}{oo}%
     {%

--- a/coqtheorem.sty
+++ b/coqtheorem.sty
@@ -28,6 +28,7 @@
   \let\corollary\relax
 
   \newcommand{\genFancyTheoremEnvironment}[1]{%
+    \expandafter\newcommand\csname #1AuxCoqautorefname\endcsname{\csname #1autorefname\endcsname}
     \spnewtheorem{#1Aux}{}{\bfseries\theoremtype}{\itshape}
     \spnewtheorem{#1AuxCoq}[#1Aux]{}{\bfseries \coqlink[\theoremname]{\theoremtype}}{{\bfseries\showname}\itshape\label{coq:\theoremname}}
     \NewDocumentEnvironment{#1}{oo}%


### PR DESCRIPTION
`coqtheorem` is not working correctly with `\autoref` and `llncs.sty`. 

The first problem is llncs related, and can be fixed as described [here](http://tex.stackexchange.com/questions/317282/lncs-class-doesnt-like-autoref).

Afterwards, `\autoref` cannot find the autorefname of coqtheorems, because the internal enviroment name is ending in "AuxCoq". The patch defines the autorefname for the coqtheorem ending in "AuxCoq" to use the autorefname of theorem without the suffix.

The other issue is the counter name, which also has an "Aux" suffix: This patch instructs `\spnewtheorem` to use the counter of the theorem, possibly creating the counter if it exists.